### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -21,7 +21,7 @@ class syntax_plugin_hiddenSwitch extends DokuWiki_Syntax_Plugin {
     $this->Lexer->addSpecialPattern('<hiddenSwitch[^>]*>', $mode,'plugin_hiddenSwitch');
   }
 
-  function handle($match, $state, $pos, &$handler) {
+  function handle($match, $state, $pos, Doku_Handler $handler) {
       $return = array('text' => $this->getLang('default'));
       $match = trim(utf8_substr($match, 14, -1)); //14 = strlen("<hiddenSwitch ")
       if ( $match !== '' ){
@@ -31,7 +31,7 @@ class syntax_plugin_hiddenSwitch extends DokuWiki_Syntax_Plugin {
       return $return;
   } // handle()
 
-  function render($mode, &$renderer, $data) {
+  function render($mode, Doku_Renderer $renderer, $data) {
     if($mode == 'xhtml'){
         $renderer->doc .= '<input type="button" class="button hiddenSwitch" value="' . $data['text'] . '" />';
       return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.